### PR TITLE
Refactor: mutationfn.ts 

### DIFF
--- a/client/src/api/mutationfn.ts
+++ b/client/src/api/mutationfn.ts
@@ -2,23 +2,19 @@ import axios from 'axios';
 import { Subscribe } from '../types/subscribe.ts';
 import { SERVER_URL } from './url.ts';
 
-export interface Comment {
-  id: string;
-  content: string;
-  url: string;
-  tag: string;
-  accessToken: string | null;
-}
-
 interface MutationProp {
   url: string;
   accessToken: string | null;
 }
 
-interface MethodFormProp {
+export interface Comment extends MutationProp {
+  id: string;
+  content: string;
+  tag: string;
+}
+
+interface MethodFormProp extends MutationProp {
   formData: FormData;
-  url: string;
-  accessToken: string | null;
 }
 
 /* ------------------------------ POST METHOD (FORMDATA)------------------------------ */

--- a/client/src/api/mutationfn.ts
+++ b/client/src/api/mutationfn.ts
@@ -148,6 +148,21 @@ export const postFeedComment = async (body: PostFeedCommentProp) => {
   return result;
 };
 
+/* ------------------------------ 피드게시물 댓글 수정 ------------------------------ */
+export const patchFeedComment = async (body: PostFeedCommentProp) => {
+  const { url, accessToken, content, feedId } = body;
+  const result = await axios.patch(
+    url,
+    { content, feedId },
+    {
+      headers: {
+        Authorization: accessToken,
+      },
+    },
+  );
+  return result;
+};
+
 /* -------------------------------- 산책게시물 생성 -------------------------------- */
 interface FillWalkPosProp {
   title: string;

--- a/client/src/api/mutationfn.ts
+++ b/client/src/api/mutationfn.ts
@@ -15,8 +15,66 @@ interface MutationProp {
   accessToken: string | null;
 }
 
+interface MethodFormProp {
+  formData: FormData;
+  url: string;
+  accessToken: string | null;
+}
+
+/* ------------------------------ POST METHOD (FORMDATA)------------------------------ */
+
+export const postFormMuation = async (body: MethodFormProp) => {
+  const { formData, url, accessToken } = body;
+  const result = await axios.post(url, formData, {
+    headers: {
+      'Content-Type': 'multipart/form-data',
+      Authorization: accessToken,
+    },
+  });
+  return result.data;
+};
+
+/* ------------------------------ PATCH METHOD ------------------------------ */
+export const patchMutation = async (body: MutationProp) => {
+  const { url, accessToken } = body;
+  const result = await axios.patch(
+    url,
+    {},
+    {
+      headers: {
+        Authorization: accessToken,
+      },
+    },
+  );
+  return result;
+};
+
+/* ------------------------------ PATCH METHOD (FORMDATA)------------------------------ */
+
+export const patchFormMuation = async (body: MethodFormProp) => {
+  const { formData, url, accessToken } = body;
+  const result = await axios.patch(url, formData, {
+    headers: {
+      'Content-Type': 'multipart/form-data',
+      Authorization: accessToken,
+    },
+  });
+  return result.data;
+};
+
+/* ------------------------------ DELETE METHOD ------------------------------ */
+export const deleteMutation = async (body: MutationProp) => {
+  const { url, accessToken } = body;
+  const result = await axios.delete(url, {
+    headers: {
+      Authorization: accessToken,
+    },
+  });
+  return result;
+};
+
 /* ------------------------------ 피드, 산책 댓글 수정 ------------------------------ */
-export const editComment = async (body: Comment) => {
+export const patchComment = async (body: Comment) => {
   const { id, content, url, tag, accessToken } = body;
 
   const data = tag === 'feed' ? { feedId: id, content } : { content };
@@ -31,12 +89,11 @@ export const editComment = async (body: Comment) => {
 };
 
 /* -------------------------------- 산책 댓글 생성 -------------------------------- */
-export interface AddComment {
+export interface PostComment extends MutationProp {
   content: string;
-  url: string;
-  accessToken: string | null;
 }
-export const addComment = async (body: AddComment) => {
+
+export const postComment = async (body: PostComment) => {
   const { content, url, accessToken } = body;
 
   const result = await axios.post(
@@ -53,33 +110,13 @@ export const addComment = async (body: AddComment) => {
   return result.data;
 };
 
-/* -------------------------------- 산책 댓글 삭제 -------------------------------- */
-export interface DeleteComment {
-  url: string;
-  accessToken: string | null;
-}
-export const deleteComment = async (body: DeleteComment) => {
-  const { url, accessToken } = body;
-
-  const result = await axios.delete(url, {
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: accessToken,
-    },
-  });
-
-  return result.data;
-};
-
 /* -------------------------------- 회원 정보 추가 / 수정 -------------------------------- */
-export interface UserInfo {
+export interface PatchUserInfo extends MutationProp {
   nickname: string;
   address: string;
-  url: string;
-  accessToken: string | null;
 }
 
-export const fillUserInfo = async (body: UserInfo) => {
+export const patchUserInfo = async (body: PatchUserInfo) => {
   const { nickname, address, url, accessToken } = body;
 
   const result = await axios.patch(
@@ -95,178 +132,23 @@ export const fillUserInfo = async (body: UserInfo) => {
   return result.data;
 };
 
-/* -------------------------------- 펫 등록, 수정 -------------------------------- */
-// 로직 분리하기
-type PostPetProp = {
-  formData: FormData;
-  url: string;
-  accessToken: string;
-};
-
-export const postPet = async (body: PostPetProp) => {
-  const { formData, url, accessToken } = body;
-  const result = await axios.post(url, formData, {
-    headers: {
-      'Content-Type': 'multipart/form-data',
-      Authorization: accessToken,
-    },
-  });
-  return result.data;
-};
-
-export const patchPet = async (body: PostPetProp) => {
-  const { formData, url, accessToken } = body;
-  const result = await axios.patch(url, formData, {
-    headers: {
-      'Content-Type': 'multipart/form-data',
-      Authorization: accessToken,
-    },
-  });
-  return result.data;
-};
-
-/* -------------------------------- 펫 삭제 -------------------------------- */
-interface DeletePetProp {
-  url: string;
-  token: string;
-}
-export const deletePet = async (body: DeletePetProp) => {
-  const { url, token } = body;
-  const result = await axios.delete(url, {
-    headers: {
-      Authorization: token,
-    },
-  });
-  return result;
-};
-
-/* -------------------------------- 유저 프로필 변경-------------------------------- */
-// interface PatchUserProfileProp {
-//   url: string;
-//   accessToken: string;
-// }
-export const patchUserProfile = async (body: MutationProp) => {
-  const { url, accessToken } = body;
-  const result = await axios.patch(
-    url,
-    {},
-    {
-      headers: {
-        Authorization: accessToken,
-      },
-    },
-  );
-  return result.data.imageURL;
-};
-
-/* -------------------------------- 피드게시물 생성 -------------------------------- */
-interface FeedPostingProp {
-  url: string;
-  accessToken: string | null;
-  formData: FormData;
-}
-export const postFeed = async (body: FeedPostingProp) => {
-  const { url, accessToken, formData } = body;
-  const result = await axios.post(url, formData, {
-    headers: {
-      'Content-Type': 'multipart/form-data',
-      Authorization: accessToken,
-    },
-  });
-  return result.data;
-};
-
-/* -------------------------------- 피드게시물 수정 -------------------------------- */
-
-export const patchFeed = async (body: FeedPostingProp) => {
-  const { url, accessToken, formData } = body;
-  const result = await axios.patch(url, formData, {
-    headers: {
-      'Content-Type': 'multipart/form-data',
-      Authorization: accessToken,
-    },
-  });
-  return result;
-};
-
-/* -------------------------------- 피드게시물 삭제 -------------------------------- */
-interface DeleteFeedProp {
-  url: string;
-  token: string | null;
-}
-
-export const deleteFeed = async (body: DeleteFeedProp) => {
-  const { url, token } = body;
-  const result = await axios.delete(url, {
-    headers: {
-      Authorization: token,
-    },
-  });
-  return result;
-};
-
-/* -------------------------------- 피드게시물 좋아요  -------------------------------- */
-
-export const patchFeedLike = async (body: MutationProp) => {
-  const { url, accessToken } = body;
-  const result = await axios.patch(
-    url,
-    {},
-    {
-      headers: {
-        Authorization: accessToken,
-      },
-    },
-  );
-  return result;
-};
-
 /* -------------------------------- 피드게시물 댓글 작성  -------------------------------- */
-
-interface PostFeedCommentProp {
-  url: string;
-  token: string;
+interface PostFeedCommentProp extends MutationProp {
   content: string;
   feedId: number;
 }
 
 export const postFeedComment = async (body: PostFeedCommentProp) => {
-  const { url, token, content, feedId } = body;
+  const { url, accessToken, content, feedId } = body;
   const result = await axios.post(
     url,
     { content, feedId },
     {
       headers: {
-        Authorization: token,
+        Authorization: accessToken,
       },
     },
   );
-  return result;
-};
-
-/* -------------------------------- 피드게시물 댓글 수정  -------------------------------- */
-export const patchFeedComment = async (body: PostFeedCommentProp) => {
-  const { url, token, content, feedId } = body;
-  const result = await axios.patch(
-    url,
-    { content, feedId },
-    {
-      headers: {
-        Authorization: token,
-      },
-    },
-  );
-  return result;
-};
-
-/* -------------------------------- 피드게시물 댓글 삭제  -------------------------------- */
-export const deleteFeedComment = async (body: MutationProp) => {
-  const { url, accessToken } = body;
-  const result = await axios.delete(url, {
-    headers: {
-      Authorization: accessToken,
-    },
-  });
   return result;
 };
 
@@ -309,11 +191,8 @@ export const postWalkFeed = async (payload: FillWalkPosProp) => {
 };
 
 /* -------------------------------- 구독 갱신 -------------------------------- */
-interface SubscribeProp {
-  url: string;
-  accessToken: string;
-}
-export const postSubscribe = async (body: SubscribeProp) => {
+
+export const postSubscribe = async (body: MutationProp) => {
   const { url, accessToken } = body;
   const result = await axios.post<Subscribe>(
     url,
@@ -322,42 +201,9 @@ export const postSubscribe = async (body: SubscribeProp) => {
   );
   return result.data;
 };
-/* -------------------------------- 산책 게시물 모집 변경 -------------------------------- */
-interface WalkStatusProp {
-  url: string;
-  accessToken: string;
-}
-export const patchWalkStatus = async (body: WalkStatusProp) => {
-  const { url, accessToken } = body;
-  const result = await axios.patch(
-    url,
-    {},
-    { headers: { Authorization: accessToken } },
-  );
-  return result.data;
-};
-
-/* -------------------------------- 산책 게시물 삭제 -------------------------------- */
-
-export const deleteWalkFeed = async (body: WalkStatusProp) => {
-  const { url, accessToken } = body;
-  const result = await axios.delete(url, {
-    headers: { Authorization: accessToken },
-  });
-  return result.data;
-};
 
 /* -------------------------------- 산책 게시물 수정 -------------------------------- */
-interface PatchWalkPosProp {
-  title: string;
-  content: string;
-  mapURL: string;
-  chatURL: string;
-  location: string;
-  time: string;
-  open: boolean;
-  maximum: number;
-  accessToken: string;
+interface PatchWalkPosProp extends FillWalkPosProp {
   walkId: number;
 }
 
@@ -383,20 +229,5 @@ export const patchWalkFeed = async (payload: PatchWalkPosProp) => {
       },
     },
   );
-  return result.data;
-};
-
-/* -------------------------------- 회원 탈퇴 -------------------------------- */
-interface PostQuitMemberProp {
-  accessToken: string | null;
-}
-
-export const postQuitMember = async (payload: PostQuitMemberProp) => {
-  const { accessToken } = payload;
-
-  const result = await axios.delete(`${SERVER_URL}/auth/kakao/unlink`, {
-    headers: { Authorization: accessToken },
-  });
-
   return result.data;
 };

--- a/client/src/api/url.ts
+++ b/client/src/api/url.ts
@@ -1,6 +1,6 @@
 export const SERVER_URL =
   window.location.hostname === 'localhost'
-    ? 'http://43.202.86.53:8080'
+    ? 'http://15.165.146.215:8080'
     : `/api`;
 
 export const ZIP_URL =

--- a/client/src/common/comment/Comment.tsx
+++ b/client/src/common/comment/Comment.tsx
@@ -3,7 +3,7 @@ import { useState, useEffect, useContext } from 'react';
 import { useForm, SubmitHandler } from 'react-hook-form';
 import { Link } from 'react-router-dom';
 import { useReadLocalStorage } from 'usehooks-ts';
-import { deleteComment, editComment } from '../../api/mutationfn.ts';
+import { deleteMutation, patchComment } from '../../api/mutationfn.ts';
 import { SERVER_URL } from '../../api/url.ts';
 import { ReactComponent as Write } from '../../assets/button/write.svg';
 import { MemberIdContext, State } from '../../store/Context.tsx';
@@ -93,7 +93,7 @@ export default function Comment(props: CommentProp) {
   const queryClient = useQueryClient();
   // mutation
   const mutation = useMutation({
-    mutationFn: editComment,
+    mutationFn: patchComment,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['walkFeed', walkMatePostId] });
       setIsEdited(false);
@@ -104,7 +104,7 @@ export default function Comment(props: CommentProp) {
   });
 
   const deleteCommentMutaion = useMutation({
-    mutationFn: deleteComment,
+    mutationFn: deleteMutation,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['walkFeed', walkMatePostId] });
     },

--- a/client/src/common/comment/feedComment/FeedComment.tsx
+++ b/client/src/common/comment/feedComment/FeedComment.tsx
@@ -2,10 +2,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useState, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useReadLocalStorage } from 'usehooks-ts';
-import {
-  deleteFeedComment,
-  patchFeedComment,
-} from '../../../api/mutationfn.ts';
+import { deleteMutation, patchMutation } from '../../../api/mutationfn.ts';
 import { SERVER_URL } from '../../../api/url.ts';
 import { ReactComponent as Write } from '../../../assets/button/write.svg';
 import { BooleanStr } from '../../../types/propType.ts';
@@ -45,12 +42,12 @@ export default function FeedComment({
   time,
 }: Prop) {
   const navigate = useNavigate();
-  const accessToken = useReadLocalStorage('accessToken');
+  const accessToken = useReadLocalStorage<string | null>('accessToken');
   const [isEditOpen, setIsEditOpen] = useState<boolean>(false);
   const queryClient = useQueryClient();
 
   const commentEditMuation = useMutation({
-    mutationFn: patchFeedComment,
+    mutationFn: patchMutation,
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: ['feedPopUp', feedid],
@@ -60,7 +57,7 @@ export default function FeedComment({
   });
 
   const commentDeleteMutation = useMutation({
-    mutationFn: deleteFeedComment,
+    mutationFn: deleteMutation,
     onSuccess: () =>
       queryClient.invalidateQueries({
         queryKey: ['feedPopUp', feedid],
@@ -78,7 +75,7 @@ export default function FeedComment({
         content: inputRef.current.value.trim(),
         feedId: feedid,
         url: `${SERVER_URL}/feeds/comments/${commentid}`,
-        token: accessToken as string,
+        accessToken,
       };
       commentEditMuation.mutate(body);
     }
@@ -91,7 +88,7 @@ export default function FeedComment({
   const handleDelete = () => {
     const body = {
       url: `${SERVER_URL}/feeds/comments/${commentid}`,
-      accessToken: accessToken as string,
+      accessToken,
     };
     commentDeleteMutation.mutate(body);
   };

--- a/client/src/common/comment/feedComment/FeedComment.tsx
+++ b/client/src/common/comment/feedComment/FeedComment.tsx
@@ -2,7 +2,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useState, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useReadLocalStorage } from 'usehooks-ts';
-import { deleteMutation, patchMutation } from '../../../api/mutationfn.ts';
+import { deleteMutation, patchFeedComment } from '../../../api/mutationfn.ts';
 import { SERVER_URL } from '../../../api/url.ts';
 import { ReactComponent as Write } from '../../../assets/button/write.svg';
 import { BooleanStr } from '../../../types/propType.ts';
@@ -47,7 +47,7 @@ export default function FeedComment({
   const queryClient = useQueryClient();
 
   const commentEditMuation = useMutation({
-    mutationFn: patchMutation,
+    mutationFn: patchFeedComment,
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: ['feedPopUp', feedid],

--- a/client/src/common/input/feedInput/FeedInput.tsx
+++ b/client/src/common/input/feedInput/FeedInput.tsx
@@ -12,7 +12,7 @@ interface Prop {
 }
 
 export default function FeedInput({ feedid, blankhandler }: Prop) {
-  const accessToken = useReadLocalStorage('accessToken');
+  const accessToken = useReadLocalStorage<string | null>('accessToken');
   const inputRef = useRef<HTMLInputElement>(null);
   const queryClient = useQueryClient();
   const { mutate } = useMutation({
@@ -33,7 +33,7 @@ export default function FeedInput({ feedid, blankhandler }: Prop) {
         return blankhandler([true, '공백은 입력할 수 없어요.']);
       const data = {
         url: `${SERVER_URL}/feeds/comments`,
-        token: accessToken as string,
+        accessToken,
         content: inputRef.current.value.trim(),
         feedId: feedid,
       };

--- a/client/src/components/card/feed-card/FeedCard.tsx
+++ b/client/src/components/card/feed-card/FeedCard.tsx
@@ -43,7 +43,7 @@ export default function FeedCard({
 }: Prop) {
   const navigate = useNavigate();
   const [isMore, setIsMore] = useState(false);
-  const accessToken = useReadLocalStorage('accessToken');
+  const accessToken = useReadLocalStorage<string | null>('accessToken');
 
   const handlerClick = () => {
     if (!accessToken)

--- a/client/src/components/card/feedwritecard/FeedWriteCard.tsx
+++ b/client/src/components/card/feedwritecard/FeedWriteCard.tsx
@@ -4,7 +4,7 @@ import { useParams, useNavigate } from 'react-router-dom';
 import { Navigation } from 'swiper/modules';
 import { Swiper, SwiperSlide } from 'swiper/react';
 import { useReadLocalStorage } from 'usehooks-ts';
-import { patchFeed, postFeed } from '../../../api/mutationfn.ts';
+import { patchFormMuation, postFormMuation } from '../../../api/mutationfn.ts';
 import { getServerDataWithJwt } from '../../../api/queryfn.ts';
 import { SERVER_URL } from '../../../api/url.ts';
 import { ReactComponent as Close } from '../../../assets/button/close.svg';
@@ -85,7 +85,7 @@ export default function FeedWriteCard() {
 
   // 피드 게시물 올리기 mutation
   const feedPostingMutation = useMutation({
-    mutationFn: postFeed,
+    mutationFn: postFormMuation,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['myPage'] });
       queryClient.invalidateQueries({ queryKey: ['myFeed'] });
@@ -97,7 +97,7 @@ export default function FeedWriteCard() {
 
   // 피드 게시물 수정하기 mutation
   const feedEditingMutation = useMutation({
-    mutationFn: patchFeed,
+    mutationFn: patchFormMuation,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['feedPopUp'] });
       navigate(`/my-page`);

--- a/client/src/components/card/sidenav/SideNav.tsx
+++ b/client/src/components/card/sidenav/SideNav.tsx
@@ -2,7 +2,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useState } from 'react';
 import { useMatch, useNavigate } from 'react-router-dom';
 import { useReadLocalStorage } from 'usehooks-ts';
-import { patchFeedLike } from '../../../api/mutationfn.ts';
+import { patchMutation } from '../../../api/mutationfn.ts';
 import { SERVER_URL } from '../../../api/url.ts';
 import { ReactComponent as Comment } from '../../../assets/button/comment.svg';
 import { ReactComponent as Delete } from '../../../assets/button/delete.svg';
@@ -45,7 +45,7 @@ export default function SideNav({
   const [isLikes, setIsLikes] = useState<number>(likes);
 
   const likeMutation = useMutation({
-    mutationFn: patchFeedLike,
+    mutationFn: patchMutation,
     onSuccess: ({ data }) => {
       queryClient.invalidateQueries({ queryKey: ['feedPopUp'] });
       setIsLike(data.isLike.toString());

--- a/client/src/components/pet/PetInfo.tsx
+++ b/client/src/components/pet/PetInfo.tsx
@@ -3,7 +3,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useState, useEffect } from 'react';
 import { useForm, SubmitHandler } from 'react-hook-form';
 import { useReadLocalStorage } from 'usehooks-ts';
-import { patchPet, postPet } from '../../api/mutationfn.ts';
+import { patchFormMuation, postFormMuation } from '../../api/mutationfn.ts';
 import { SERVER_URL } from '../../api/url.ts';
 import { ReactComponent as Close } from '../../assets/button/close.svg';
 import { ReactComponent as Man } from '../../assets/label/man.svg';
@@ -48,7 +48,7 @@ export default function PetInfo(prop: Prop) {
   const [isDisabled, setIsDisabled] = useState(false);
 
   // token
-  const accessToken = useReadLocalStorage<string>('accessToken');
+  const accessToken = useReadLocalStorage<string | null>('accessToken');
 
   // 유저 정보 refatch
   const queryClient = useQueryClient();
@@ -74,7 +74,7 @@ export default function PetInfo(prop: Prop) {
 
   // mutation 작성
   const petPostMutation = useMutation({
-    mutationFn: postPet,
+    mutationFn: postFormMuation,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['myPage'] });
       setIsOpened(false);
@@ -86,7 +86,7 @@ export default function PetInfo(prop: Prop) {
   });
 
   const petPatchMutation = useMutation({
-    mutationFn: patchPet,
+    mutationFn: patchFormMuation,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['myPage'] });
       setIsOpened(false);
@@ -115,7 +115,7 @@ export default function PetInfo(prop: Prop) {
       const data = {
         formData,
         url: `${SERVER_URL}/pets`,
-        accessToken: accessToken as string,
+        accessToken,
       };
       petPostMutation.mutate(data);
     }
@@ -123,7 +123,7 @@ export default function PetInfo(prop: Prop) {
       const data = {
         formData,
         url: `${SERVER_URL}/pets/status/${petId}`,
-        accessToken: accessToken as string,
+        accessToken,
       };
       petPatchMutation.mutate(data);
     }

--- a/client/src/components/subscribe/Subscribe.tsx
+++ b/client/src/components/subscribe/Subscribe.tsx
@@ -14,7 +14,7 @@ export default function Subscribe({ guestFollow, usersId }: Prop) {
   const queryClient = useQueryClient();
 
   // 구독 갱신
-  const accessToken = useReadLocalStorage('accessToken');
+  const accessToken = useReadLocalStorage<string | null>('accessToken');
   const subscribeMutation = useMutation({
     mutationFn: postSubscribe,
     onSuccess() {
@@ -29,7 +29,7 @@ export default function Subscribe({ guestFollow, usersId }: Prop) {
   const handleSubscribe = () => {
     subscribeMutation.mutate({
       url: `${SERVER_URL}/members/following/${usersId}`,
-      accessToken: accessToken as string,
+      accessToken,
     });
   };
 

--- a/client/src/components/user_my_page/pet-container/PetContainer.tsx
+++ b/client/src/components/user_my_page/pet-container/PetContainer.tsx
@@ -1,7 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useState } from 'react';
 import { useReadLocalStorage } from 'usehooks-ts';
-import { deletePet, patchUserProfile } from '../../../api/mutationfn.ts';
+import { deleteMutation, patchMutation } from '../../../api/mutationfn.ts';
 import { SERVER_URL } from '../../../api/url.ts';
 import Popup from '../../../common/popup/Popup.tsx';
 import PetInfo from '../../pet/PetInfo.tsx';
@@ -47,7 +47,7 @@ export default function PetContainer(prop: Prop) {
 
   // 펫 삭제 확인 팝업 작성
   const [isDeletePopUp, setIsDeletePopUp] = useState(false);
-  const accessToken = useReadLocalStorage('accessToken');
+  const accessToken = useReadLocalStorage<string | null>('accessToken');
 
   // 펫 삭제 오류 팝업
   const [isDelelteError, setIsDeleteError] = useState(false);
@@ -57,7 +57,7 @@ export default function PetContainer(prop: Prop) {
 
   // 펫 삭제 로직 작성
   const deletePetMutation = useMutation({
-    mutationFn: deletePet,
+    mutationFn: deleteMutation,
     onSuccess() {
       setIsDeletePopUp(false);
       queryClient.invalidateQueries({ queryKey: ['myPage'] });
@@ -71,7 +71,7 @@ export default function PetContainer(prop: Prop) {
   const handleDeletePet = () => {
     deletePetMutation.mutate({
       url: `${SERVER_URL}/pets/${petId}`,
-      token: accessToken as string,
+      accessToken,
     });
   };
 
@@ -81,7 +81,7 @@ export default function PetContainer(prop: Prop) {
 
   // 유저 프로필 이미지 변경
   const mutationPatchUserProfile = useMutation({
-    mutationFn: patchUserProfile,
+    mutationFn: patchMutation,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['myPage'] });
     },

--- a/client/src/pages/feedPopUp/FeedPopUp.tsx
+++ b/client/src/pages/feedPopUp/FeedPopUp.tsx
@@ -2,7 +2,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useContext, useEffect, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useReadLocalStorage } from 'usehooks-ts';
-import { deleteFeed } from '../../api/mutationfn.ts';
+import { deleteMutation } from '../../api/mutationfn.ts';
 import { getServerData, getServerDataWithJwt } from '../../api/queryfn.ts';
 import { SERVER_URL } from '../../api/url.ts';
 import { ReactComponent as Close } from '../../assets/button/close.svg';
@@ -28,7 +28,7 @@ import {
 } from './FeedPopUp.styled';
 
 export function Component() {
-  const accessToken = useReadLocalStorage('accessToken');
+  const accessToken = useReadLocalStorage<string | null>('accessToken');
   const state = useContext(MemberIdContext);
   const navigate = useNavigate();
   const queryClient = useQueryClient();
@@ -58,7 +58,7 @@ export function Component() {
   });
 
   const deleteFeedMutation = useMutation({
-    mutationFn: deleteFeed,
+    mutationFn: deleteMutation,
     onSuccess: async () => {
       await queryClient.invalidateQueries({ queryKey: ['guestFeed'] });
       navigate('/my-page');
@@ -70,7 +70,7 @@ export function Component() {
     if (data) {
       const body = {
         url: `${SERVER_URL}/feeds/${data.feedId}`,
-        token: accessToken as string,
+        accessToken,
       };
       deleteFeedMutation.mutate(body);
     }

--- a/client/src/pages/home/Home.tsx
+++ b/client/src/pages/home/Home.tsx
@@ -27,7 +27,7 @@ import '../../common/carousel/carousel.css';
 
 export function Component() {
   const queryClient = useQueryClient();
-  const accessToken = useReadLocalStorage<string>('accessToken');
+  const accessToken = useReadLocalStorage<string | null>('accessToken');
   const [isFirstVisited, setFirstVisited] = useLocalStorage(
     'firstVisited',
     true,

--- a/client/src/pages/info/Info.tsx
+++ b/client/src/pages/info/Info.tsx
@@ -10,7 +10,7 @@ import {
   useParams,
 } from 'react-router-dom';
 import { useReadLocalStorage } from 'usehooks-ts';
-import { fillUserInfo, postQuitMember } from '../../api/mutationfn.ts';
+import { patchUserInfo, deleteMutation } from '../../api/mutationfn.ts';
 import { SERVER_URL } from '../../api/url.ts';
 import { ReactComponent as Like } from '../../assets/button/like.svg';
 import { ReactComponent as Logo } from '../../assets/logo.svg';
@@ -72,11 +72,11 @@ export function Component() {
   // 주소 값 받아오기
   const [zip, setZip] = useState('');
 
-  const accessToken = useReadLocalStorage<string>('accessToken');
+  const accessToken = useReadLocalStorage<string | null>('accessToken');
 
   // 회원가입 등록 Mutation
   const userInfoFillMutation = useMutation({
-    mutationFn: fillUserInfo,
+    mutationFn: patchUserInfo,
     onSuccess: () => {
       if (userId) return navigate('/my-page');
       navigate('/home');
@@ -171,7 +171,7 @@ export function Component() {
 
   // 회원탈퇴 mutaition
   const userQuitMutation = useMutation({
-    mutationFn: postQuitMember,
+    mutationFn: deleteMutation,
     onSuccess() {
       localStorage.removeItem('accessToken');
       localStorage.removeItem('refreshToken');
@@ -185,7 +185,11 @@ export function Component() {
 
   const onSubmitQuit = (data: QuitProps) => {
     if (data.quitText) {
-      userQuitMutation.mutate({ accessToken });
+      const body = {
+        url: `${SERVER_URL}/auth/kakao/unlink`,
+        accessToken,
+      };
+      userQuitMutation.mutate(body);
     }
   };
 

--- a/client/src/pages/login/Login.tsx
+++ b/client/src/pages/login/Login.tsx
@@ -9,7 +9,7 @@ import { Container, LoginBtn, LoginText, GuestText } from './Login.styled.tsx';
 
 export default function Login() {
   const navigate = useNavigate();
-  const accessToken = useReadLocalStorage('accessToken');
+  const accessToken = useReadLocalStorage<string | null>('accessToken');
 
   const [firstVisited, setFirstVisited] = useLocalStorage<boolean | null>(
     'firstVisited',
@@ -33,7 +33,7 @@ export default function Login() {
     <Container>
       <Logo width="400" className="max-sm:w-80" />
       <img src={LoginPets} width="500" />
-      <Link to="https://kauth.kakao.com/oauth/authorize?client_id=07df97c2858e60b2e19f630c2c397b31&redirect_uri=http://43.202.86.53:8080/auth/kakao/callback&response_type=code">
+      <Link to="https://kauth.kakao.com/oauth/authorize?client_id=07df97c2858e60b2e19f630c2c397b31&redirect_uri=http://15.165.146.215:8080/auth/kakao/callback&response_type=code">
         <LoginBtn>
           <Kakao />
           <LoginText>Log in With KaKao</LoginText>

--- a/client/src/pages/myPage/MyPage.tsx
+++ b/client/src/pages/myPage/MyPage.tsx
@@ -60,7 +60,7 @@ export function Component() {
   // 마이 info 데이터 불러오기
   const state = useContext(MemberIdContext);
 
-  const accessToken = useReadLocalStorage<string>('accessToken');
+  const accessToken = useReadLocalStorage<string | null>('accessToken');
 
   // 자신의 유저 정보 조회
   const {

--- a/client/src/pages/userpage/UserPage.tsx
+++ b/client/src/pages/userpage/UserPage.tsx
@@ -43,7 +43,7 @@ export function Component() {
 
   const memberId = useContext(MemberIdContext);
 
-  const accessToken = useReadLocalStorage<string>('accessToken');
+  const accessToken = useReadLocalStorage<string | null>('accessToken');
 
   // 구독 controller
   const [isSubscribed, setIsSubscribed] = useState(false);

--- a/client/src/pages/walkEditing/WalkEditing.tsx
+++ b/client/src/pages/walkEditing/WalkEditing.tsx
@@ -43,7 +43,7 @@ export function Component() {
     formState: { errors },
   } = useForm<Inputs>();
 
-  const accessToken = useReadLocalStorage('accessToken');
+  const accessToken = useReadLocalStorage<string | null>('accessToken');
   // 산책 게시물 불러오기
   const { data, isLoading } = useQuery<WalkFeed>({
     queryKey: ['walkFeed', postId],

--- a/client/src/pages/walkFeed/WalkFeed.tsx
+++ b/client/src/pages/walkFeed/WalkFeed.tsx
@@ -4,9 +4,9 @@ import { SubmitHandler, useForm } from 'react-hook-form';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useReadLocalStorage } from 'usehooks-ts';
 import {
-  addComment,
-  deleteWalkFeed,
-  patchWalkStatus,
+  postComment,
+  deleteMutation,
+  patchMutation,
 } from '../../api/mutationfn';
 import { getServerDataWithJwt } from '../../api/queryfn.ts';
 import { SERVER_URL } from '../../api/url.ts';
@@ -44,8 +44,8 @@ export function Component() {
   const [isOpen, setIsOpen] = useState<[boolean, string]>([false, '']);
 
   // 댓글 등록
-  const addCommentMutation = useMutation({
-    mutationFn: addComment,
+  const postCommentMutation = useMutation({
+    mutationFn: postComment,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['walkFeed', postId] });
       queryClient.invalidateQueries({ queryKey: ['walkmateList'] });
@@ -69,7 +69,7 @@ export function Component() {
       content: data.content.trim(),
     };
     const url = `${SERVER_URL}/walkmates/comments/${postId}`;
-    addCommentMutation.mutate({ ...data, url, accessToken });
+    postCommentMutation.mutate({ ...data, url, accessToken });
     resetField('content');
   };
 
@@ -98,7 +98,7 @@ export function Component() {
 
   // 모집 변경
   const walkStatusMutation = useMutation({
-    mutationFn: patchWalkStatus,
+    mutationFn: patchMutation,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['walkFeed', postId] });
     },
@@ -110,7 +110,7 @@ export function Component() {
       url: `${SERVER_URL}/walkmates/openstatus/${!data?.open}/${
         data?.walkMatePostId
       }`,
-      accessToken: accessToken as string,
+      accessToken,
     });
   };
 
@@ -122,7 +122,7 @@ export function Component() {
 
   // 게시글 삭제
   const walkDeleteMutation = useMutation({
-    mutationFn: deleteWalkFeed,
+    mutationFn: deleteMutation,
     onSuccess: () => {
       navigate('/walkmate');
     },
@@ -136,7 +136,7 @@ export function Component() {
   const handleWalkFeedDelete = () => {
     walkDeleteMutation.mutate({
       url: `${SERVER_URL}/walkmates/${data?.walkMatePostId}`,
-      accessToken: accessToken as string,
+      accessToken,
     });
   };
 

--- a/client/src/pages/walkPosting/WalkPosting.tsx
+++ b/client/src/pages/walkPosting/WalkPosting.tsx
@@ -41,7 +41,7 @@ export function Component() {
     formState: { errors },
   } = useForm<Inputs>();
 
-  const accessToken = useReadLocalStorage('accessToken');
+  const accessToken = useReadLocalStorage<string | null>('accessToken');
   // 산책게시물 등록 POST
   const walkPostFillMutation = useMutation({
     mutationFn: postWalkFeed,

--- a/client/src/store/Context.tsx
+++ b/client/src/store/Context.tsx
@@ -42,7 +42,7 @@ const initaldate: State = {
 
 export default function ContextProvider({ children }: Props) {
   const [state, dispatch] = useReducer(reducer, initaldate);
-  const accessToken = useReadLocalStorage('accessToken');
+  const accessToken = useReadLocalStorage<string | null>('accessToken');
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { data } = useQuery<UserInfo>({


### PR DESCRIPTION
### What is this PR?
-  patch, post, delete 겹치는 로직 모두 공통으로 분리해 활용하였습니다.
- prop으로 활용되는 부분을 모두 interface로 변경하였습니다.
- 중복되는 interface의 프로퍼티가 있는 경우, extends로 활용해 코드분량을 줄였습니다.
- 코드 124 추가 / 281 감소 (거의 파일의 절반 감소)

### mutationfn.ts 위주로 코드를 확인해주세요.
- 이외의 파일들은 mutation 함수명을 공통으로 처리하면서 (patch~~,post~~로 시작되게 통일) 수정보았습니다.
- 또한 공통으로 로직분리할 수 있는 함수는 지워 공통mutation으로 대치하였습니다.

### Screenshot
- extend한 interface
<img width="514" alt="스크린샷 2023-08-10 오전 11 58 30" src="https://github.com/SharePetment/SharePetment/assets/82816029/18aa2d5e-65db-4415-8374-4f5791f972c2">

- 공통으로 관리한 mutation
<img width="950" alt="스크린샷 2023-08-10 오전 11 58 38" src="https://github.com/SharePetment/SharePetment/assets/82816029/814a6753-708f-474c-8c02-d83cc408a9fb">
