### PR TITLE
Refactor: mutation hook처리 

### DIFF
--- a/client/src/api/mutationfn.ts
+++ b/client/src/api/mutationfn.ts
@@ -148,21 +148,6 @@ export const postFeedComment = async (body: PostFeedCommentProp) => {
   return result;
 };
 
-/* ------------------------------ 피드게시물 댓글 수정 ------------------------------ */
-export const patchFeedComment = async (body: PostFeedCommentProp) => {
-  const { url, accessToken, content, feedId } = body;
-  const result = await axios.patch(
-    url,
-    { content, feedId },
-    {
-      headers: {
-        Authorization: accessToken,
-      },
-    },
-  );
-  return result;
-};
-
 /* -------------------------------- 산책게시물 생성 -------------------------------- */
 interface FillWalkPosProp {
   title: string;

--- a/client/src/common/input/feedInput/FeedInput.tsx
+++ b/client/src/common/input/feedInput/FeedInput.tsx
@@ -1,7 +1,5 @@
-import { useQueryClient, useMutation } from '@tanstack/react-query';
 import { useRef } from 'react';
 import { useReadLocalStorage } from 'usehooks-ts';
-import { postFeedComment } from '@/api/mutationfn.ts';
 import { SERVER_URL } from '@/api/url.ts';
 import { ReactComponent as Write } from '@/assets/button/write.svg';
 import {
@@ -9,6 +7,7 @@ import {
   Input,
   CommentBtn,
 } from '@/common/input/feedInput/FeedInput.styled';
+import usePostFeedCommentMutation from '@/hook/api/mutation/usePostFeedCommentMutation';
 
 interface Prop {
   feedid: number;
@@ -18,14 +17,9 @@ interface Prop {
 export default function FeedInput({ feedid, blankhandler }: Prop) {
   const accessToken = useReadLocalStorage<string | null>('accessToken');
   const inputRef = useRef<HTMLInputElement>(null);
-  const queryClient = useQueryClient();
-  const { mutate } = useMutation({
-    mutationFn: postFeedComment,
-    onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: ['feedPopUp', feedid],
-      });
-    },
+
+  const { mutate } = usePostFeedCommentMutation({
+    key: ['feedPopUp', feedid],
   });
 
   const handleClick = () => {

--- a/client/src/components/card/feedwritecard/FeedWriteCard.tsx
+++ b/client/src/components/card/feedwritecard/FeedWriteCard.tsx
@@ -1,10 +1,8 @@
-import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useState, useCallback, useRef, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { Navigation } from 'swiper/modules';
 import { Swiper, SwiperSlide } from 'swiper/react';
 import { useReadLocalStorage } from 'usehooks-ts';
-import { postFormMuation } from '@/api/mutationfn.ts';
 import { SERVER_URL } from '@/api/url.ts';
 import { ReactComponent as Close } from '@/assets/button/close.svg';
 import { ReactComponent as Plus } from '@/assets/button/plus.svg';
@@ -22,6 +20,7 @@ import {
 import LoadingComponent from '@/components/loading/LoadingComponent.tsx';
 import NoticeServerError from '@/components/notice/NoticeServerError.tsx';
 import usePatchFormMutation from '@/hook/api/mutation/usePatchFormMutation';
+import usePostFormMutation from '@/hook/api/mutation/usePostFormMutation';
 import useFeedDetailQuery from '@/hook/api/query/useFeedDetailQuery';
 import Path from '@/routers/paths.ts';
 import { FeedImage } from '@/types/feedTypes.ts';
@@ -32,7 +31,6 @@ import 'swiper/css/navigation';
 import '@/common/carousel/carousel.css';
 
 export default function FeedWriteCard() {
-  const queryClient = useQueryClient();
   const { feedId } = useParams();
   const navigate = useNavigate();
   const textRef = useRef<HTMLTextAreaElement>(null);
@@ -76,16 +74,10 @@ export default function FeedWriteCard() {
     secondEnable: getQuery,
   });
 
-  // 피드 게시물 올리기 mutation
-  const feedPostingMutation = useMutation({
-    mutationFn: postFormMuation,
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['myPage'] });
-      queryClient.invalidateQueries({ queryKey: ['myFeed'] });
-      queryClient.invalidateQueries({ queryKey: ['followList'] });
-      navigate(Path.MyPage);
-    },
-    onError: () => setIsOpen([true, '요청에 실패했습니다.']),
+  const feedPostingMutation = usePostFormMutation({
+    key: ['myPage', 'myFeed', 'followList'],
+    successFn: () => navigate(Path.MyPage),
+    errorFn: () => setIsOpen([true, '요청에 실패했습니다.']),
   });
 
   // 피드 게시물 수정하기 mutation

--- a/client/src/components/card/feedwritecard/FeedWriteCard.tsx
+++ b/client/src/components/card/feedwritecard/FeedWriteCard.tsx
@@ -4,7 +4,7 @@ import { useParams, useNavigate } from 'react-router-dom';
 import { Navigation } from 'swiper/modules';
 import { Swiper, SwiperSlide } from 'swiper/react';
 import { useReadLocalStorage } from 'usehooks-ts';
-import { patchFormMuation, postFormMuation } from '@/api/mutationfn.ts';
+import { postFormMuation } from '@/api/mutationfn.ts';
 import { SERVER_URL } from '@/api/url.ts';
 import { ReactComponent as Close } from '@/assets/button/close.svg';
 import { ReactComponent as Plus } from '@/assets/button/plus.svg';
@@ -21,6 +21,7 @@ import {
 } from '@/components/card/feedwritecard/FeedWriteCard.styled.tsx';
 import LoadingComponent from '@/components/loading/LoadingComponent.tsx';
 import NoticeServerError from '@/components/notice/NoticeServerError.tsx';
+import usePatchFormMutation from '@/hook/api/mutation/usePatchFormMutation';
 import useFeedDetailQuery from '@/hook/api/query/useFeedDetailQuery';
 import Path from '@/routers/paths.ts';
 import { FeedImage } from '@/types/feedTypes.ts';
@@ -88,13 +89,10 @@ export default function FeedWriteCard() {
   });
 
   // 피드 게시물 수정하기 mutation
-  const feedEditingMutation = useMutation({
-    mutationFn: patchFormMuation,
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['feedPopUp'] });
-      navigate(Path.MyPage);
-    },
-    onError: () => setIsOpen([true, '요청에 실패했습니다.']),
+  const feedEditingMutation = usePatchFormMutation({
+    key: ['feedPopUp'],
+    successFn: () => navigate(Path.MyPage),
+    errorFn: () => setIsOpen([true, '요청에 실패했습니다.']),
   });
 
   const handleSubmit = () => {

--- a/client/src/components/pet/PetInfo.tsx
+++ b/client/src/components/pet/PetInfo.tsx
@@ -1,9 +1,7 @@
 import { ErrorMessage } from '@hookform/error-message';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useState, useEffect } from 'react';
 import { useForm, SubmitHandler } from 'react-hook-form';
 import { useReadLocalStorage } from 'usehooks-ts';
-import { postFormMuation } from '@/api/mutationfn.ts';
 import { SERVER_URL } from '@/api/url.ts';
 import { ReactComponent as Close } from '@/assets/button/close.svg';
 import { ReactComponent as Man } from '@/assets/label/man.svg';
@@ -20,6 +18,7 @@ import Popup from '@/common/popup/Popup.tsx';
 import { Container, Form, RadioBox } from '@/components/pet/petInfo.styled.tsx';
 import PetProfile from '@/components/pet/petProfile/PetProfile.tsx';
 import usePatchFormMutation from '@/hook/api/mutation/usePatchFormMutation';
+import usePostFormMutation from '@/hook/api/mutation/usePostFormMutation';
 
 type Prop = {
   isOpend: boolean;
@@ -51,9 +50,6 @@ export default function PetInfo(prop: Prop) {
   // token
   const accessToken = useReadLocalStorage<string | null>('accessToken');
 
-  // 유저 정보 refatch
-  const queryClient = useQueryClient();
-
   // 프로필에 사용
   const [image, setImage] = useState(profile);
   const [file, setFile] = useState<File | null>(null);
@@ -74,13 +70,10 @@ export default function PetInfo(prop: Prop) {
   const [isError, setIsError] = useState(false);
 
   // mutation 작성
-  const petPostMutation = useMutation({
-    mutationFn: postFormMuation,
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['myPage'] });
-      setIsOpened(false);
-    },
-    onError: () => {
+  const petPostMutation = usePostFormMutation({
+    key: ['myPage'],
+    successFn: () => setIsOpened(false),
+    errorFn: () => {
       setIsDisabled(false);
       setIsError(true);
     },

--- a/client/src/components/pet/PetInfo.tsx
+++ b/client/src/components/pet/PetInfo.tsx
@@ -3,7 +3,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useState, useEffect } from 'react';
 import { useForm, SubmitHandler } from 'react-hook-form';
 import { useReadLocalStorage } from 'usehooks-ts';
-import { patchFormMuation, postFormMuation } from '@/api/mutationfn.ts';
+import { postFormMuation } from '@/api/mutationfn.ts';
 import { SERVER_URL } from '@/api/url.ts';
 import { ReactComponent as Close } from '@/assets/button/close.svg';
 import { ReactComponent as Man } from '@/assets/label/man.svg';
@@ -19,6 +19,7 @@ import { PopupBackGround } from '@/common/popup/popup.styled.tsx';
 import Popup from '@/common/popup/Popup.tsx';
 import { Container, Form, RadioBox } from '@/components/pet/petInfo.styled.tsx';
 import PetProfile from '@/components/pet/petProfile/PetProfile.tsx';
+import usePatchFormMutation from '@/hook/api/mutation/usePatchFormMutation';
 
 type Prop = {
   isOpend: boolean;
@@ -85,13 +86,10 @@ export default function PetInfo(prop: Prop) {
     },
   });
 
-  const petPatchMutation = useMutation({
-    mutationFn: patchFormMuation,
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['myPage'] });
-      setIsOpened(false);
-    },
-    onError: () => setIsError(true),
+  const petPatchMutation = usePatchFormMutation({
+    key: ['myPage'],
+    successFn: () => setIsOpened(false),
+    errorFn: () => setIsError(true),
   });
 
   // submit Handler 작성

--- a/client/src/components/subscribe/Subscribe.tsx
+++ b/client/src/components/subscribe/Subscribe.tsx
@@ -1,8 +1,7 @@
-import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useReadLocalStorage } from 'usehooks-ts';
-import { postSubscribe } from '@/api/mutationfn.ts';
 import { SERVER_URL } from '@/api/url.ts';
 import { SubScribeButton } from '@/components/subscribe/subscribe.styled.tsx';
+import useSubscribeMutation from '@/hook/api/mutation/useSubscribeMutation';
 
 interface Prop {
   guestFollow: boolean | undefined;
@@ -10,22 +9,13 @@ interface Prop {
 }
 
 export default function Subscribe({ guestFollow, usersId }: Prop) {
-  // query 갱신하기
-  const queryClient = useQueryClient();
-
-  // 구독 갱신
   const accessToken = useReadLocalStorage<string | null>('accessToken');
-  const subscribeMutation = useMutation({
-    mutationFn: postSubscribe,
-    onSuccess() {
-      queryClient.invalidateQueries({
-        queryKey: ['followList'],
-      });
-      queryClient.invalidateQueries({
-        queryKey: ['userPage', usersId],
-      });
-    },
+
+  // 구독 mutation
+  const subscribeMutation = useSubscribeMutation({
+    keys: [['followList'], ['userPage', usersId as string]],
   });
+
   const handleSubscribe = () => {
     subscribeMutation.mutate({
       url: `${SERVER_URL}/members/following/${usersId}`,

--- a/client/src/components/user_my_page/pet-container/PetContainer.tsx
+++ b/client/src/components/user_my_page/pet-container/PetContainer.tsx
@@ -2,7 +2,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useState } from 'react';
 import { useReadLocalStorage } from 'usehooks-ts';
 import PetInfoBox from '../petinfo-box/PetInfoBox.tsx';
-import { deleteMutation, patchMutation } from '@/api/mutationfn.ts';
+import { patchMutation } from '@/api/mutationfn.ts';
 import { SERVER_URL } from '@/api/url.ts';
 import Popup from '@/common/popup/Popup.tsx';
 import PetInfo from '@/components/pet/PetInfo.tsx';
@@ -13,6 +13,7 @@ import {
   PetCheckTrue,
   SettingPet,
 } from '@/components/user_my_page/pet-container/petContainer.styled.tsx';
+import useDeleteMutation from '@/hook/api/mutation/useDeleteMutation.tsx';
 
 interface Prop {
   name: string;
@@ -56,13 +57,11 @@ export default function PetContainer(prop: Prop) {
   const [isEditError, setIsEditError] = useState(false);
 
   // 펫 삭제 로직 작성
-  const deletePetMutation = useMutation({
-    mutationFn: deleteMutation,
-    onSuccess() {
-      setIsDeletePopUp(false);
-      queryClient.invalidateQueries({ queryKey: ['myPage'] });
-    },
-    onError() {
+
+  const deletePetMutation = useDeleteMutation({
+    keys: [['myPage']],
+    successFn: () => setIsDeletePopUp(false),
+    errorFn: () => {
       setIsDeletePopUp(false);
       setIsDeleteError(true);
     },

--- a/client/src/components/user_my_page/pet-container/PetContainer.tsx
+++ b/client/src/components/user_my_page/pet-container/PetContainer.tsx
@@ -1,8 +1,6 @@
-import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useState } from 'react';
 import { useReadLocalStorage } from 'usehooks-ts';
 import PetInfoBox from '../petinfo-box/PetInfoBox.tsx';
-import { patchMutation } from '@/api/mutationfn.ts';
 import { SERVER_URL } from '@/api/url.ts';
 import Popup from '@/common/popup/Popup.tsx';
 import PetInfo from '@/components/pet/PetInfo.tsx';
@@ -14,6 +12,7 @@ import {
   SettingPet,
 } from '@/components/user_my_page/pet-container/petContainer.styled.tsx';
 import useDeleteMutation from '@/hook/api/mutation/useDeleteMutation.tsx';
+import usePatchMutation from '@/hook/api/mutation/usePatchMutation.tsx';
 
 interface Prop {
   name: string;
@@ -39,9 +38,6 @@ export default function PetContainer(prop: Prop) {
     isPetCheck,
     index,
   } = prop;
-
-  // 유저 정보 refatch
-  const queryClient = useQueryClient();
 
   // 펫 등록 수정 띄위기
   const [isPetOpened, setIsPetOpened] = useState(false);
@@ -78,15 +74,9 @@ export default function PetContainer(prop: Prop) {
     setIsDeletePopUp(true);
   };
 
-  // 유저 프로필 이미지 변경
-  const mutationPatchUserProfile = useMutation({
-    mutationFn: patchMutation,
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['myPage'] });
-    },
-    onError: () => {
-      setIsEditError(true);
-    },
+  const mutationPatchUserProfile = usePatchMutation({
+    key: ['myPage'],
+    errorFn: () => setIsEditError(true),
   });
 
   // 유저 프로필 변경

--- a/client/src/hook/api/mutation/mutationProp.ts
+++ b/client/src/hook/api/mutation/mutationProp.ts
@@ -1,0 +1,6 @@
+export interface MutationProp {
+  keys?: (string | number)[][];
+  key?: string[];
+  successFn?: () => void;
+  errorFn: () => void;
+}

--- a/client/src/hook/api/mutation/useDeleteMutation.tsx
+++ b/client/src/hook/api/mutation/useDeleteMutation.tsx
@@ -1,0 +1,28 @@
+import { useQueryClient, useMutation } from '@tanstack/react-query';
+import { deleteMutation } from '@/api/mutationfn';
+
+interface DeleteMutationProp {
+  keys?: (string | number)[][];
+  successFn?: () => void;
+  errorFn?: () => void;
+}
+
+export default function useDeleteMutation({
+  successFn,
+  keys,
+  errorFn,
+}: DeleteMutationProp) {
+  const queryClient = useQueryClient();
+  const { mutate, isLoading } = useMutation({
+    mutationFn: deleteMutation,
+    onSuccess: () => {
+      if (keys)
+        keys.map(key => queryClient.invalidateQueries({ queryKey: key }));
+      if (successFn) successFn();
+    },
+    onError: () => {
+      if (errorFn) errorFn();
+    },
+  });
+  return { mutate, isLoading };
+}

--- a/client/src/hook/api/mutation/usePatchFormMutation.tsx
+++ b/client/src/hook/api/mutation/usePatchFormMutation.tsx
@@ -1,0 +1,27 @@
+import { useQueryClient, useMutation } from '@tanstack/react-query';
+import { patchFormMuation } from '@/api/mutationfn';
+
+interface PatchFormMutationProp {
+  key: string[];
+  successFn: () => void;
+  errorFn: () => void;
+}
+
+export default function usePatchFormMutation({
+  key,
+  successFn,
+  errorFn,
+}: PatchFormMutationProp) {
+  const queryClient = useQueryClient();
+  const { mutate, isLoading } = useMutation({
+    mutationFn: patchFormMuation,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: key });
+      if (successFn) successFn();
+    },
+    onError: () => {
+      if (errorFn) errorFn();
+    },
+  });
+  return { mutate, isLoading };
+}

--- a/client/src/hook/api/mutation/usePatchMutation.tsx
+++ b/client/src/hook/api/mutation/usePatchMutation.tsx
@@ -1,18 +1,18 @@
 import { useQueryClient, useMutation } from '@tanstack/react-query';
 import { MutationProp } from './mutationProp';
-import { postFormMuation } from '@/api/mutationfn';
+import { patchMutation } from '@/api/mutationfn';
 
-export default function usePostFormMutation({
+export default function usePatchMutation({
   keys,
   successFn,
   errorFn,
 }: MutationProp) {
   const queryClient = useQueryClient();
   const { mutate, isLoading } = useMutation({
-    mutationFn: postFormMuation,
+    mutationFn: patchMutation,
     onSuccess: () => {
-      keys.map(key => queryClient.invalidateQueries({ queryKey: [key] }));
-      successFn();
+      queryClient.invalidateQueries({ queryKey: keys });
+      if (successFn) successFn();
     },
     onError: () => errorFn(),
   });

--- a/client/src/hook/api/mutation/usePatchUserInfoMutation.tsx
+++ b/client/src/hook/api/mutation/usePatchUserInfoMutation.tsx
@@ -1,0 +1,17 @@
+import { useMutation } from '@tanstack/react-query';
+import { MutationProp } from './mutationProp';
+import { patchUserInfo } from '@/api/mutationfn';
+
+export default function usePatchUserInfoMutation({
+  successFn,
+  errorFn,
+}: MutationProp) {
+  const { mutate } = useMutation({
+    mutationFn: patchUserInfo,
+    onSuccess: () => {
+      if (successFn) successFn();
+    },
+    onError: () => errorFn(),
+  });
+  return { mutate };
+}

--- a/client/src/hook/api/mutation/usePostCommentMutation.tsx
+++ b/client/src/hook/api/mutation/usePostCommentMutation.tsx
@@ -1,0 +1,23 @@
+import { useQueryClient, useMutation } from '@tanstack/react-query';
+import { MutationProp } from './mutationProp';
+import { postComment } from '@/api/mutationfn';
+
+export default function usePostCommentMutation({
+  keys,
+  errorFn,
+}: MutationProp) {
+  const queryClient = useQueryClient();
+  const { mutate } = useMutation({
+    mutationFn: postComment,
+    onSuccess: () => {
+      if (keys)
+        keys.map(key =>
+          queryClient.invalidateQueries({
+            queryKey: key,
+          }),
+        );
+    },
+    onError: () => errorFn(),
+  });
+  return { mutate };
+}

--- a/client/src/hook/api/mutation/usePostFeedCommentMutation.tsx
+++ b/client/src/hook/api/mutation/usePostFeedCommentMutation.tsx
@@ -1,0 +1,15 @@
+import { useQueryClient, useMutation } from '@tanstack/react-query';
+import { postFeedComment } from '@/api/mutationfn';
+
+interface MutationProp {
+  key: (string | number)[];
+}
+
+export default function usePostFeedCommentMutation({ key }: MutationProp) {
+  const queryClient = useQueryClient();
+  const { mutate } = useMutation({
+    mutationFn: postFeedComment,
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: key }),
+  });
+  return { mutate };
+}

--- a/client/src/hook/api/mutation/usePostFormMutation.tsx
+++ b/client/src/hook/api/mutation/usePostFormMutation.tsx
@@ -1,0 +1,3 @@
+export default function usePostFormMutation() {
+  return <div>usePostFormMutation</div>;
+}

--- a/client/src/hook/api/mutation/useSubscribeMutation.tsx
+++ b/client/src/hook/api/mutation/useSubscribeMutation.tsx
@@ -1,0 +1,16 @@
+import { useQueryClient, useMutation } from '@tanstack/react-query';
+import { postSubscribe } from '@/api/mutationfn';
+
+interface MutationProp {
+  keys: (string | number)[][];
+}
+
+export default function useSubscribeMutation({ keys }: MutationProp) {
+  const queryClient = useQueryClient();
+  const { mutate } = useMutation({
+    mutationFn: postSubscribe,
+    onSuccess: () =>
+      keys.map(key => queryClient.invalidateQueries({ queryKey: key })),
+  });
+  return { mutate };
+}

--- a/client/src/pages/feedPopUp/FeedPopUp.tsx
+++ b/client/src/pages/feedPopUp/FeedPopUp.tsx
@@ -1,8 +1,6 @@
-import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useContext, useEffect, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useReadLocalStorage } from 'usehooks-ts';
-import { deleteMutation } from '@/api/mutationfn.ts';
 import { SERVER_URL } from '@/api/url.ts';
 import { ReactComponent as Close } from '@/assets/button/close.svg';
 import Comment from '@/common/comment/Comment';
@@ -13,6 +11,7 @@ import SideNav from '@/components/card/sidenav/SideNav';
 import LoadingComponent from '@/components/loading/LoadingComponent';
 import NoticeServerError from '@/components/notice/NoticeServerError';
 import Toast from '@/components/toast/Toast';
+import useDeleteMutation from '@/hook/api/mutation/useDeleteMutation';
 import useGuestFeedQuery from '@/hook/api/query/useGuestFeedQuery';
 import useHostFeedQuery from '@/hook/api/query/useHostFeedQuery';
 import {
@@ -32,7 +31,6 @@ export function Component() {
   const accessToken = useReadLocalStorage<string | null>('accessToken');
   const state = useContext(MemberIdContext);
   const navigate = useNavigate();
-  const queryClient = useQueryClient();
   const { feedId } = useParams();
 
   // 알림 토스트 및 팝업창 state
@@ -55,13 +53,10 @@ export function Component() {
     accessToken,
   });
 
-  const deleteFeedMutation = useMutation({
-    mutationFn: deleteMutation,
-    onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: ['guestFeed'] });
-      navigate(Path.MyPage);
-    },
-    onError: () => setIsOpen([true, '요청에 실패했어요.']),
+  const deleteFeedMutation = useDeleteMutation({
+    keys: [['guestFeed']],
+    successFn: () => navigate(Path.MyPage),
+    errorFn: () => setIsOpen([true, '요청에 실패했어요.']),
   });
 
   const handlerDelete = () => {

--- a/client/src/pages/info/Info.tsx
+++ b/client/src/pages/info/Info.tsx
@@ -1,5 +1,4 @@
 import { ErrorMessage } from '@hookform/error-message';
-import { useMutation } from '@tanstack/react-query';
 import axios from 'axios';
 import { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
@@ -10,7 +9,6 @@ import {
   useParams,
 } from 'react-router-dom';
 import { useReadLocalStorage } from 'usehooks-ts';
-import { patchUserInfo } from '@/api/mutationfn.ts';
 import { SERVER_URL } from '@/api/url.ts';
 import { ReactComponent as Like } from '@/assets/button/like.svg';
 import { ReactComponent as Logo } from '@/assets/logo.svg';
@@ -26,6 +24,7 @@ import {
 import Popup from '@/common/popup/Popup.tsx';
 import Select from '@/common/select/Select.tsx';
 import useDeleteMutation from '@/hook/api/mutation/useDeleteMutation';
+import usePatchUserInfoMutation from '@/hook/api/mutation/usePatchUserInfoMutation';
 import {
   ConfirmButton,
   ExtraInfoLogo,
@@ -81,15 +80,12 @@ export function Component() {
   const accessToken = useReadLocalStorage<string | null>('accessToken');
 
   // 회원가입 등록 Mutation
-  const userInfoFillMutation = useMutation({
-    mutationFn: patchUserInfo,
-    onSuccess: () => {
+  const userInfoFillMutation = usePatchUserInfoMutation({
+    successFn: () => {
       if (userId) return navigate(Path.MyPage);
       navigate(Path.Home);
     },
-    onError: () => {
-      navigate(Path.Login);
-    },
+    errorFn: () => navigate(Path.Login),
   });
 
   useEffect(() => {

--- a/client/src/pages/info/Info.tsx
+++ b/client/src/pages/info/Info.tsx
@@ -10,7 +10,7 @@ import {
   useParams,
 } from 'react-router-dom';
 import { useReadLocalStorage } from 'usehooks-ts';
-import { patchUserInfo, deleteMutation } from '@/api/mutationfn.ts';
+import { patchUserInfo } from '@/api/mutationfn.ts';
 import { SERVER_URL } from '@/api/url.ts';
 import { ReactComponent as Like } from '@/assets/button/like.svg';
 import { ReactComponent as Logo } from '@/assets/logo.svg';
@@ -25,6 +25,7 @@ import {
 } from '@/common/input/Input.styled.tsx';
 import Popup from '@/common/popup/Popup.tsx';
 import Select from '@/common/select/Select.tsx';
+import useDeleteMutation from '@/hook/api/mutation/useDeleteMutation';
 import {
   ConfirmButton,
   ExtraInfoLogo,
@@ -175,17 +176,14 @@ export function Component() {
   const [isError, setIsError] = useState(false);
 
   // 회원탈퇴 mutaition
-  const userQuitMutation = useMutation({
-    mutationFn: deleteMutation,
-    onSuccess() {
+  const userQuitMutation = useDeleteMutation({
+    successFn: () => {
       localStorage.removeItem('accessToken');
       localStorage.removeItem('refreshToken');
       localStorage.removeItem('firstVisited');
       navigate(Path.Login);
     },
-    onError() {
-      setIsError(true);
-    },
+    errorFn: () => setIsError(true),
   });
 
   const onSubmitQuit = (data: QuitProps) => {

--- a/client/src/pages/walkFeed/WalkFeed.tsx
+++ b/client/src/pages/walkFeed/WalkFeed.tsx
@@ -1,9 +1,7 @@
-import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useContext, useEffect, useState } from 'react';
 import { SubmitHandler, useForm } from 'react-hook-form';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useReadLocalStorage } from 'usehooks-ts';
-import { postComment, patchMutation } from '@/api/mutationfn';
 import { SERVER_URL } from '@/api/url.ts';
 import { ReactComponent as CommentIcon } from '@/assets/button/comment.svg';
 import { ReactComponent as Delete } from '@/assets/button/delete.svg';
@@ -19,6 +17,8 @@ import LoadingComponent from '@/components/loading/LoadingComponent.tsx';
 import ShowMap from '@/components/map-show/ShowMap.tsx';
 import NoticeServerError from '@/components/notice/NoticeServerError.tsx';
 import useDeleteMutation from '@/hook/api/mutation/useDeleteMutation';
+import usePatchMutation from '@/hook/api/mutation/usePatchMutation';
+import usePostCommentMutation from '@/hook/api/mutation/usePostCommentMutation';
 import useMypageQuery from '@/hook/api/query/useMypageQuery';
 import useWalkFeedQuery from '@/hook/api/query/useWalkFeedQuery';
 import {
@@ -36,7 +36,6 @@ export function Component() {
   const { postId } = useParams();
   const { memberId: userId } = useContext(MemberIdContext) as State;
   const accessToken = useReadLocalStorage<string | null>('accessToken');
-  const queryClient = useQueryClient();
 
   // 지도 그리기
   // 위도, 경도, 주소
@@ -82,24 +81,16 @@ export function Component() {
   });
 
   /* ------------------------------ Mutation ------------------------------ */
-
   // 모집 변경
-  const walkStatusMutation = useMutation({
-    mutationFn: patchMutation,
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['walkFeed', postId] });
-    },
-    onError: () => setIsOpen([true, '모집 변경에 실패했습니다.']),
+  const walkStatusMutation = usePatchMutation({
+    key: ['walkFeed', postId as string],
+    errorFn: () => setIsOpen([true, '모집 변경에 실패했습니다.']),
   });
 
   // 댓글 등록
-  const postCommentMutation = useMutation({
-    mutationFn: postComment,
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['walkFeed', postId] });
-      queryClient.invalidateQueries({ queryKey: ['walkmateList'] });
-    },
-    onError: () => setIsOpen([true, '댓글 생성에 실패했습니다.']),
+  const postCommentMutation = usePostCommentMutation({
+    keys: [['walkFeed', postId as string], ['walkmateList']],
+    errorFn: () => setIsOpen([true, '댓글 생성에 실패했습니다.']),
   });
 
   const walkDeleteMutation = useDeleteMutation({

--- a/client/src/pages/walkFeed/WalkFeed.tsx
+++ b/client/src/pages/walkFeed/WalkFeed.tsx
@@ -3,7 +3,7 @@ import { useContext, useEffect, useState } from 'react';
 import { SubmitHandler, useForm } from 'react-hook-form';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useReadLocalStorage } from 'usehooks-ts';
-import { postComment, deleteMutation, patchMutation } from '@/api/mutationfn';
+import { postComment, patchMutation } from '@/api/mutationfn';
 import { SERVER_URL } from '@/api/url.ts';
 import { ReactComponent as CommentIcon } from '@/assets/button/comment.svg';
 import { ReactComponent as Delete } from '@/assets/button/delete.svg';
@@ -18,6 +18,7 @@ import Popup from '@/common/popup/Popup.tsx';
 import LoadingComponent from '@/components/loading/LoadingComponent.tsx';
 import ShowMap from '@/components/map-show/ShowMap.tsx';
 import NoticeServerError from '@/components/notice/NoticeServerError.tsx';
+import useDeleteMutation from '@/hook/api/mutation/useDeleteMutation';
 import useMypageQuery from '@/hook/api/query/useMypageQuery';
 import useWalkFeedQuery from '@/hook/api/query/useWalkFeedQuery';
 import {
@@ -101,13 +102,9 @@ export function Component() {
     onError: () => setIsOpen([true, '댓글 생성에 실패했습니다.']),
   });
 
-  // 게시글 삭제
-  const walkDeleteMutation = useMutation({
-    mutationFn: deleteMutation,
-    onSuccess: () => {
-      navigate(Path.WalkMate);
-    },
-    onError: () => setIsOpen([true, '게시글 삭제에 실패했습니다.']),
+  const walkDeleteMutation = useDeleteMutation({
+    successFn: () => navigate(Path.WalkMate),
+    errorFn: () => setIsOpen([true, '게시글 삭제에 실패했습니다.']),
   });
 
   /* ------------------------------ Handler ------------------------------ */


### PR DESCRIPTION
### What is this PR?
- 자주쓰이는 mutation들을 모두 hook처리하였습니다.
- onSuccess 이후, data가 필요한 로직들은 수정하지 않았습니다.
- 모두 mutation.fn 기준, 함수 기반으로 분리하였습니다.

### Screenshot
#### 로직 분리한 코드 예시
<img width="629" alt="스크린샷 2023-08-15 오전 10 41 59" src="https://github.com/SharePetment/SharePetment/assets/82816029/b2c58378-bb41-4881-a8b3-a04ab4c9a612">
<img width="588" alt="스크린샷 2023-08-15 오전 10 41 28" src="https://github.com/SharePetment/SharePetment/assets/82816029/82bf383e-1a6d-4118-ab61-fe01babc29e7">

#### 분리하지 않은 코드 예시 (data가 쓰이는 경우)
<img width="692" alt="스크린샷 2023-08-15 오전 10 41 12" src="https://github.com/SharePetment/SharePetment/assets/82816029/9a2e05f4-340b-420c-ae1a-f1e33390fa04">